### PR TITLE
Смена должности для рации

### DIFF
--- a/Content.Server/Radio/EntitySystems/RadioSystem.cs
+++ b/Content.Server/Radio/EntitySystems/RadioSystem.cs
@@ -34,8 +34,8 @@ public sealed class RadioSystem : EntitySystem
     [Dependency] private readonly IPrototypeManager _prototype = default!;
     [Dependency] private readonly IRobustRandom _random = default!;
     [Dependency] private readonly ChatSystem _chat = default!;
-    [Dependency] private readonly StationRecordsSystem _recordsSystem = default!; //vanilla-station
-    [Dependency] private readonly StationSystem _station = default!; //Vanilla-station
+    [Dependency] private readonly StationRecordsSystem _recordsSystem = default!;
+    [Dependency] private readonly StationSystem _station = default!;
 
     // set used to prevent radio feedback loops.
     private readonly HashSet<string> _messages = new();

--- a/Content.Server/Radio/EntitySystems/RadioSystem.cs
+++ b/Content.Server/Radio/EntitySystems/RadioSystem.cs
@@ -17,7 +17,6 @@ using Robust.Shared.Random;
 using Robust.Shared.Replays;
 using Robust.Shared.Utility;
 using JetBrains.Annotations;
-//Vanilla-start
 using Content.Shared.StationRecords;
 using Content.Server.StationRecords.Systems;
 using Content.Server.Station.Systems;

--- a/Content.Server/Radio/EntitySystems/RadioSystem.cs
+++ b/Content.Server/Radio/EntitySystems/RadioSystem.cs
@@ -106,21 +106,19 @@ public sealed class RadioSystem : EntitySystem
         var station = _station.GetOwningStation(messageSource);
         var role = "Неизвестно";
 
-        if (station != null) // ээаауауаэээы
+        if (station != null)
         {
-            // Сохраняем коллекцию записей IEnumerable типа GeneralStationRecord(Альтернативное решение через LINQ для конкретной записи)
             var records = _recordsSystem.GetRecordsOfType<GeneralStationRecord>(station.Value);
-
-            // Деструктурируем кортеж при помощи ключа и самой записи
             foreach (var (key, record) in records)
             {
-                if (record.Name == speakerName) // Сравниваем короче имя "чубрика" с источником сообщения дабы не возникло конфликтов
+                if (record.Name == speakerName)
                 {
                     role = record.JobTitle;
+                    break;
                 }
             }
         }
-        //Vanilla-end
+        //Rayten-end
         var wrappedMessage = Loc.GetString(speech.Bold ? "chat-radio-message-wrap-bold" : "chat-radio-message-wrap",
             ("color", channel.Color),
             ("fontType", speech.FontId),

--- a/Content.Server/Radio/EntitySystems/RadioSystem.cs
+++ b/Content.Server/Radio/EntitySystems/RadioSystem.cs
@@ -107,7 +107,7 @@ public sealed class RadioSystem : EntitySystem
         // Сохраняем текущую станцию и имя индивидуального отправителя через мета-данные(слава Богу)
         var speakerName = MetaData(messageSource).EntityName;
         var station = _station.GetOwningStation(messageSource);
-        var role = "Unknown"; // Предустановка на всякий
+        var role = "Неизвестно";
 
         if (station != null) // ээаауауаэээы
         {

--- a/Content.Server/Radio/EntitySystems/RadioSystem.cs
+++ b/Content.Server/Radio/EntitySystems/RadioSystem.cs
@@ -101,8 +101,7 @@ public sealed class RadioSystem : EntitySystem
             ? FormattedMessage.EscapeText(message)
             : message;
 
-        // Vanilla-start
-        // Сохраняем текущую станцию и имя индивидуального отправителя через мета-данные(слава Богу)
+        // Rayten-start
         var speakerName = MetaData(messageSource).EntityName;
         var station = _station.GetOwningStation(messageSource);
         var role = "Неизвестно";

--- a/Content.Server/Radio/EntitySystems/RadioSystem.cs
+++ b/Content.Server/Radio/EntitySystems/RadioSystem.cs
@@ -20,7 +20,6 @@ using JetBrains.Annotations;
 using Content.Shared.StationRecords;
 using Content.Server.StationRecords.Systems;
 using Content.Server.Station.Systems;
-//Vanilla-end
 
 namespace Content.Server.Radio.EntitySystems;
 


### PR DESCRIPTION
<!-- Рекомендации: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## Описание PR 
Смена должности теперь меняет отображаемый её префикс в сообщениях рации

## Почему / Баланс
Это очевидно необходимо, ответом является сама логика смены должности в "базе данных" станции

## Технические детали
Удалена старая логика, добавлена новая, 2 зависимости, 3 импорта (вроде)

## Медиа
![Screenshot_112](https://github.com/user-attachments/assets/63337ffb-598e-4230-ad01-510da1ba641e)

## Критические изменения
Все заебись (надеюсь), изменения коснулись исключительно ключа для форматирования канала рации

:cl:
- add: Теперь префикс в рации соответствует префиксу айди карты
