### PR TITLE
Теперь префикс в рации соответствует префиксу айди карты

### DIFF
--- a/Resources/Locale/ru-RU/vanilla/chat.ftl
+++ b/Resources/Locale/ru-RU/vanilla/chat.ftl
@@ -1,1 +1,2 @@
 chat-manager-send-ooc-admin-wrap-message = OOC: [bold][color={ $AdminOocColor }]\[{ $AdminOOCPrefix }\] { $playerName }[/color]:[/bold] { $message }
+Radio-Job-unknown=Неизвестно


### PR DESCRIPTION
<!-- Рекомендации: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## Описание PR
Должность в рации теперь соответствует должности на айди карте, карта должна быть в слоте кпк или в кпк который в слоте кпк. Иначе будет "Неизвестно"

**Список изменений**
Добавьте запись в Changelog, чтобы игроки знали о новых функциях или изменениях, которые могут повлиять на игровой процесс.
Убедитесь, что вы прочитали рекомендации и вынесли этот шаблон Changelog из блока комментариев, чтобы он отображался.
Changelog должен иметь символ :cl:, чтобы бот распознал изменения и добавил их в список изменений игры.

:cl:
- add: Теперь префикс в рации соответствует префиксу айди карты
