### PR TITLE
скелет от 10 людей

### DIFF
--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -153,7 +153,7 @@
   - type: StationEvent
     weight: 5
     duration: 1
-    minimumPlayers: 30
+    minimumPlayers: 10
   - type: RandomEntityStorageSpawnRule
     prototype: MobSkeletonCloset
 


### PR DESCRIPTION
<!-- Рекомендации: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## Описание PR
скелет теперь может заспавниться при онлайне в 10 человек, раньше было от 30.

## Почему / Баланс
<!-- Обсудите, как это повлияет на баланс игры или объясните, почему это было изменено. Укажите ссылки на соответствующие обсуждения или issue. -->

## Технические детали
<!-- Краткое описание изменений в коде для облегчения проверки. -->

## Медиа
<!-- Прикрепите медиафайлы, если PR вносит изменения в игру (одежда, предметы, механики и т.д.).
Небольшие исправления/рефакторинг освобождаются от этого требования. -->

## Критические изменения
**Список изменений**
- tweak: Скелет из шкафа теперь может заспавниться при онлайне в 10 человек, раньше было от 30.
